### PR TITLE
Remove bundles in gitignore for deploying in heroku

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 .DS_Store
 node_modules/
-bundles/
 PIG/bundles/
-Parse-Dashboard/public/bundles/
 Parse-Dashboard/parse-dashboard-config.json
 npm-debug.log
 


### PR DESCRIPTION
The bundles are needed in Heroku in order to work
